### PR TITLE
Clusterable can now be of any type

### DIFF
--- a/dbscan.go
+++ b/dbscan.go
@@ -1,16 +1,12 @@
 package dbscan
 
-var eps = 0.2
-var minPts = 3
-
 const (
 	NOISE     = false
 	CLUSTERED = true
 )
 
 type Clusterable interface {
-	Distance(c Clusterable) float64
-	GetParams() []float64
+	Distance(c interface{}) float64
 }
 
 type Cluster []Clusterable


### PR DESCRIPTION
This change provides better flexibility when using a Clusterable which it's GetParams function needs to return more than []float64.
Now in you could do:
```go
func (a *MyPoint) Distance(b interface{}) float64 {
	b2 := b.(MyPoint)
        //...
}
```

And you don't need `GetParams` anymore